### PR TITLE
CSS fixes

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,9 +1,14 @@
+body {
+    margin: 0;
+}
 .clock{
+    height: 100dvh;
+    width: 100dvw;
     display: flex;
     justify-content: center;
     align-items: center;
 }
 .time{
-    font: 50px helvetica;
-    margin-top: 40vh;
+    font: 50px, "Helvetica", sans-serif;
+    margin: 0;
 }


### PR DESCRIPTION
1. Added margin: 0 to body

Because, body has a margin by default, and setting margin to 0 acts as a reset. One can skip it, but I do it because I want `<body>` to cover the whole screen.

2. Added height and width to div.clock

Set height to 100dvh and 100dvw to make div.clock take the whole available space.

dvw/dvh is dynamic viewport width/height and it is different from vh/vw.

I use dvh/dvw because it's better for mobile screens than just vh/vw.  
More info here: [https://web.dev/viewport-units/](https://web.dev/viewport-units/)

3. Removed manually set margin from the h1 tag

Instead of setting an arbitrary value (40vh, in the case) as margin-top to bring h1 to the center, you could just set its parent container height and width to 100dvh & 100dvw. And since div.clock is already a flex container with justify-center and items-center, the h1 will appear at the center.

4. wrapped helvetica in quotes and added sans-serif fallback

Rewrote helvetica to "Helvetica" because font names must be capitalized and within quotes. And it's a good practice to add sans-serif fallback at the end because if Helvetica is not available on some systems, font would just default to using the default sans-serif font of the operating system.

BTW, Shibine, don't just click merge, go through the new code, try to understand what it means. I wish you all the best on your journey forward.

And BTW, thank you for teaching me about the font CSS property and onload functions. I never knew about it! :sweat_smile: Thanks!